### PR TITLE
Configure Discord bot intents

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,10 @@ from handlers import skip_handler, queue_handler, skip_votes
 dotenv.load_dotenv()
 
 # Создаем объект бота
-bot = commands.Bot()
+intents = discord.Intents.default()
+intents.message_content = True
+intents.voice_states = True
+bot = commands.Bot(intents=intents)
 
 # Создаем объект для загрузки видео с YouTube
 ydl_opts = {


### PR DESCRIPTION
## Summary
- Configure default intents for the bot and enable `message_content` and `voice_states`
- Pass intents to `commands.Bot` during initialization

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68960fd6a564832fab51a3187bcd5b58