### PR TITLE
Handle empty channel in skip vote

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -34,6 +34,14 @@ async def skip_handler(interaction: Interaction) -> None:
     skip_votes[guild_id].add(interaction.user.id)
     total_members = len(interaction.user.voice.channel.voice_states.keys()) - 1
 
+    if total_members == 0:
+        voice_client.stop()
+        del skip_votes[guild_id]
+        await interaction.response.send_message(
+            "Недостаточно участников для голосования. Трек остановлен."
+        )
+        return
+
     if not len(skip_votes[guild_id]) / total_members >= 0.5:
         await interaction.response.send_message(
             f"Ты проголосовал за пропуск трека. Осталось голосов "


### PR DESCRIPTION
## Summary
- Stop track automatically when skip vote total members is zero
- Avoid division by zero by checking total member count before vote calculation

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960fdfff5c832f91472fcbea57d792