### PR TITLE
Handle voice connect errors in play_queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -156,7 +156,17 @@ async def play_queue(
     query = queues[guild_id].pop(0)
 
     if not ctx.voice_client:
-        await ctx.author.voice.channel.connect()
+        try:
+            await ctx.author.voice.channel.connect()
+        except (discord.ClientException, discord.Forbidden):
+            await track_added_message.reply(
+                "Не удалось подключиться к голосовому каналу. Проверьте права бота. Трек не будет добавлен в очередь."
+            )
+            if ctx.voice_client:
+                await ctx.voice_client.disconnect()
+            if not queues[guild_id] and guild_id in guild_semaphore:
+                del guild_semaphore[guild_id]
+            return
 
     ctx.voice_client.play(
         discord.FFmpegPCMAudio(


### PR DESCRIPTION
## Summary
- handle errors when connecting to voice channels in play_queue
- inform user if connection fails and restore queue/guild resources
- drop unplayed track instead of requeuing when connection fails
- delete semaphore only if queue is empty after a failed connection

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68960fe29544832f8a335bdbc4e0afb5