### PR TITLE
Use dataclass for track information

### DIFF
--- a/buttons.py
+++ b/buttons.py
@@ -1,8 +1,11 @@
-from typing import Dict
-from discord.ui import Button
-from handlers import skip_handler, queue_handler
+from typing import Dict, List
+
 import discord
 from discord.interactions import Interaction
+from discord.ui import Button
+
+from handlers import skip_handler, queue_handler
+from models import TrackInfo
 
 
 class SkipButton(Button):
@@ -42,7 +45,7 @@ class QueueButton(Button):
         button_callback: Обработчик нажатия кнопки для просмотра текущей очереди.
     """
 
-    def __init__(self, queues: Dict[int, list]) -> None:
+    def __init__(self, queues: Dict[int, List[TrackInfo]]) -> None:
         super().__init__(label="Очередь", style=discord.ButtonStyle.gray, emoji="🎵")
         self.queues = queues
         self.callback = self.button_callback
@@ -60,13 +63,13 @@ class RemoveButton(Button):
         style (discord.ButtonStyle): Стиль кнопки.
         emoji (str): Эмодзи для кнопки.
         queues (dict): Словарь очередей.
-        track_info (dict): Информация о треке.
+        track_info (TrackInfo): Информация о треке.
 
     Methods:
         button_callback: Обработчик нажатия кнопки для удаления трека из очереди.
     """
 
-    def __init__(self, queues: Dict[int, list], track_info: dict) -> None:
+    def __init__(self, queues: Dict[int, List[TrackInfo]], track_info: TrackInfo) -> None:
         super().__init__(label="Удалить", style=discord.ButtonStyle.gray, emoji="❌")
         self.queues = queues
         self.track_info = track_info
@@ -79,7 +82,7 @@ class RemoveButton(Button):
         Parameters:
             interaction (Interaction): Взаимодействие с кнопкой.
         """
-        if interaction.user != self.track_info["author"]:
+        if interaction.user != self.track_info.author:
             await interaction.response.send_message(
                 "Ты не можешь удалять треки, добавленные другими пользователями",
                 ephemeral=True,
@@ -88,11 +91,11 @@ class RemoveButton(Button):
 
         if self.track_info not in self.queues[interaction.guild_id]:
             await interaction.response.send_message(
-                f'Трек {self.track_info["title"]} отсутствует в очереди'
+                f"Трек {self.track_info.title} отсутствует в очереди"
             )
             return
 
         self.queues[interaction.guild_id].remove(self.track_info)
         await interaction.response.send_message(
-            f'Трек {self.track_info["title"]} был удален из очереди'
+            f"Трек {self.track_info.title} был удален из очереди"
         )

--- a/handlers.py
+++ b/handlers.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List
 from discord.interactions import Interaction
+from models import TrackInfo
 
 skip_votes = defaultdict(set)
 
@@ -46,21 +47,21 @@ async def skip_handler(interaction: Interaction) -> None:
     await interaction.response.send_message("Трек пропущен")
 
 
-async def queue_handler(interaction: Interaction, queues: Dict[int, list]) -> None:
+async def queue_handler(interaction: Interaction, queues: Dict[int, List[TrackInfo]]) -> None:
     """
     Обработчик команды для просмотра текущей очереди.
 
     Parameters:
         interaction (Interaction): Взаимодействие с кнопкой.
-        queues (Dict[int, list]): Словарь очередей.
+        queues (Dict[int, List[TrackInfo]]): Словарь очередей.
     """
     guild_id = interaction.guild_id
 
     if queues.get(guild_id):
         formatted_queue = "\n".join(
             [
-                f'{index + 1}. {query["title"]}'
-                for index, query in enumerate(queues[guild_id])
+                f"{index + 1}. {track.title}"
+                for index, track in enumerate(queues[guild_id])
             ]
         )
         message = f"Следующие треки:\n{formatted_queue}"

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from discord.webhook import WebhookMessage
 import yt_dlp
 from buttons import SkipButton, QueueButton, RemoveButton
 from handlers import skip_handler, queue_handler, skip_votes
+from models import TrackInfo
 
 # Загружаем .env
 dotenv.load_dotenv()
@@ -133,7 +134,7 @@ async def enqueue(ctx: ApplicationContext, query: str) -> Optional[WebhookMessag
             audio_url = info["entries"][0]["url"]
             title = info["entries"][0]["title"]
 
-    track_info = {"url": audio_url, "title": title, "author": ctx.author}
+    track_info = TrackInfo(url=audio_url, title=title, author=ctx.author)
     queues[ctx.guild_id].append(track_info)
 
     view = discord.ui.View(timeout=None)
@@ -153,14 +154,14 @@ async def play_queue(
     """
     guild_id = ctx.guild.id
 
-    query = queues[guild_id].pop(0)
+    track = queues[guild_id].pop(0)
 
     if not ctx.voice_client:
         await ctx.author.voice.channel.connect()
 
     ctx.voice_client.play(
         discord.FFmpegPCMAudio(
-            query["url"],
+            track.url,
             before_options="-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 -vn",
         )
     )
@@ -168,7 +169,7 @@ async def play_queue(
     view = discord.ui.View(timeout=None)
     view.add_item(SkipButton())
     view.add_item(QueueButton(queues))
-    await track_added_message.reply(f"Сейчас играет: {query['title']}", view=view)
+    await track_added_message.reply(f"Сейчас играет: {track.title}", view=view)
 
     while ctx.voice_client.is_playing():
         await asyncio.sleep(1)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+import discord
+
+
+@dataclass
+class TrackInfo:
+    url: str
+    title: str
+    author: discord.abc.User


### PR DESCRIPTION
## Summary
- add `TrackInfo` dataclass to hold track URL, title and author
- refactor queue and playback logic to use `TrackInfo` instead of dictionaries
- update queue and removal handlers to work with new dataclass

## Testing
- `python -m py_compile main.py handlers.py buttons.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68960fe49578832fba6ded7657b66b28