### PR TITLE
feat: allow selecting search result

### DIFF
--- a/buttons.py
+++ b/buttons.py
@@ -1,8 +1,9 @@
 from typing import Dict, List
 
+import asyncio
 import discord
 from discord import Interaction
-from discord.ui import Button
+from discord.ui import Button, Select
 
 from handlers import skip_handler, queue_handler
 from models import TrackInfo
@@ -99,3 +100,21 @@ class RemoveButton(Button):
         await interaction.response.send_message(
             f"Трек {self.track_info.title} был удален из очереди"
         )
+
+
+class SearchResultSelect(Select):
+    """Выпадающий список для выбора трека из результатов поиска."""
+
+    def __init__(self, entries: List[dict], future: asyncio.Future) -> None:
+        options = [
+            discord.SelectOption(label=entry["title"][:100], value=str(index))
+            for index, entry in enumerate(entries)
+        ]
+        super().__init__(placeholder="Выберите трек", options=options)
+        self.future = future
+        self.entries = entries
+
+    async def callback(self, interaction: Interaction) -> None:
+        await interaction.response.defer()
+        index = int(self.values[0])
+        self.future.set_result(self.entries[index])


### PR DESCRIPTION
## Summary
- let users choose from multiple YouTube search results via a dropdown
- enqueue selected track and keep queue management

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689633cfd4b0832fa9122dbd5034ec41