### PR TITLE
feat: add playback embeds and help command

### DIFF
--- a/models.py
+++ b/models.py
@@ -7,3 +7,4 @@ class TrackInfo:
     url: str
     title: str
     author: discord.abc.User
+    duration: int


### PR DESCRIPTION
## Summary
- show currently playing tracks in an embed with title, duration, author and live progress
- track playback progress and remaining time
- add `/help` slash command listing all available commands

## Testing
- `python -m py_compile main.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68963bef2f48832f9d9bcb8aa9f86731